### PR TITLE
first step towards rebuilding this gem ontop of pg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 tmp
 marginalia_test
 Gemfile.lock
+postgres.log

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,4 @@ gemspec
 
 version = ENV["RAILS_VERSION"] || "4.2.0"
 
-if "4.2.5" > version
-  gem 'mysql2', '~> 0.3.13'
-else
-  gem 'mysql2', '>= 0.3.13', '< 0.5'
-end
-
 gem "activerecord", "~> #{version}"

--- a/Rakefile
+++ b/Rakefile
@@ -5,57 +5,11 @@ task :default => ['test:all']
 
 namespace :test do
   desc "test all drivers"
-  task :all => [:mysql2, :postgresql, :sqlite]
-
-  desc "test mysql2 driver"
-  task :mysql2 do
-    sh "DRIVER=mysql2 ruby -Ilib -Itest test/*_test.rb"
-  end
+  task :all => [:postgresql]
 
   desc "test PostgreSQL driver"
   task :postgresql do
-    sh "DRIVER=postgresql DB_USERNAME=postgres ruby -Ilib -Itest test/*_test.rb"
+    sh "DRIVER=postgresql DB_USERNAME=postgres ruby -Ilib -Itest test/escape_test.rb"
+    sh "DRIVER=postgresql DB_USERNAME=postgres ruby -Ilib -Itest test/query_comments_test.rb"
   end
-
-  desc "test sqlite3 driver"
-  task :sqlite do
-    sh "DRIVER=sqlite3 ruby -Ilib -Itest test/*_test.rb"
-  end
-end
-
-namespace :db do
-
-  desc "reset all databases"
-  task :reset => [:"mysql:reset", :"postgresql:reset"]
-
-  namespace :mysql do
-    desc "reset MySQL database"
-    task :reset => [:drop, :create]
-
-    desc "create MySQL database"
-    task :create do
-      sh 'mysql -u root -e "create database marginalia_test;"'
-    end
-
-    desc "drop MySQL database"
-    task :drop do
-      sh 'mysql -u root -e "drop database if exists marginalia_test;"'
-    end
-  end
-
-  namespace :postgresql do
-    desc "reset PostgreSQL database"
-    task :reset => [:drop, :create]
-
-    desc "create PostgreSQL database"
-    task :create do
-      sh 'createdb -U postgres marginalia_test'
-    end
-
-    desc "drop PostgreSQL database"
-    task :drop do
-      sh 'psql -d postgres -U postgres -c "DROP DATABASE IF EXISTS marginalia_test"'
-    end
-  end
-
 end

--- a/marginalia.gemspec
+++ b/marginalia.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.version       = "1.5.0"
   gem.license       = "MIT"
 
-  gem.add_runtime_dependency "activerecord", ">= 2.3"
+  gem.add_development_dependency "activerecord", ">= 2.3"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "mysql2"
   gem.add_development_dependency "pg"

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -5,18 +5,23 @@ require 'mocha/test_unit'
 require 'logger'
 require 'pp'
 require 'active_record'
+require 'tmpdir'
 
-require 'active_record/connection_adapters/mysql2_adapter'
 require 'active_record/connection_adapters/postgresql_adapter'
-
-# patch for older versions of activerecord
-# https://stackoverflow.com/questions/21075515/creating-tables-and-problems-with-primary-key-in-rails
-class ActiveRecord::ConnectionAdapters::Mysql2Adapter
-  NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
-end
 
 # Shim for compatibility with older versions of MiniTest
 MiniTest::Test = MiniTest::Unit::TestCase unless defined?(MiniTest::Test)
+
+pg_port = 5433
+
+# TODO log all statements via log_statement=all
+pg_dir = Dir.mktmpdir
+puts %x[initdb #{pg_dir}]
+puts %x[pg_ctl -o "-p #{pg_port}" -D #{pg_dir} -l postgres.log start]
+puts %x[createdb -p #{pg_port} marginalia_test]
+
+# TODO stop database at exit
+# puts %x[pg_ctl -o "-p #{pg_port}" -D #{pg_dir} stop]
 
 # From version 4.1, ActiveRecord expects `Rails.env` to be
 # defined if `Rails` is defined
@@ -31,8 +36,9 @@ require 'marginalia'
 RAILS_ROOT = File.expand_path(File.dirname(__FILE__))
 
 ActiveRecord::Base.establish_connection({
-  :adapter  => ENV["DRIVER"] || "mysql",
+  :adapter  => ENV["DRIVER"] || "postgres",
   :host     => "localhost",
+  :port     => pg_port,
   :username => ENV["DB_USERNAME"] || "root",
   :database => "marginalia_test"
 })
@@ -51,10 +57,6 @@ Marginalia.install
 
 class MarginaliaTest < MiniTest::Test
   def setup
-    @queries = []
-    ActiveSupport::Notifications.subscribe "sql.active_record" do |*args|
-      @queries << args.last[:sql]
-    end
     Marginalia.set('app', 'rails')
   end
 
@@ -65,32 +67,23 @@ class MarginaliaTest < MiniTest::Test
     ActiveRecord::Base.connection.unstub(:annotate_sql)
   end
 
-  def test_query_commenting_on_mysql_driver_with_no_action
+  def test_query_commenting_with_no_action
     ActiveRecord::Base.connection.execute "select id from posts"
     assert_match %r{select id from posts /\*app:rails\*/$}, @queries.first
   end
 
-  if ENV["DRIVER"] =~ /^mysql/
-    def test_query_commenting_on_mysql_driver_with_binary_chars
-      ActiveRecord::Base.connection.execute "select id from posts /* \x81\x80\u0010\ */"
-      assert_equal "select id from posts /* \x81\x80\u0010 */ /*app:rails*/", @queries.first
-    end
+  def test_query_commenting_on_postgres_update
+    ActiveRecord::Base.connection.expects(:annotate_sql).returns("update posts set id = 1").once
+    ActiveRecord::Base.connection.send(:exec_update, "update posts set id = 1")
+  ensure
+    ActiveRecord::Base.connection.unstub(:annotate_sql)
   end
 
-  if ENV["DRIVER"] =~ /^postgres/
-    def test_query_commenting_on_postgres_update
-      ActiveRecord::Base.connection.expects(:annotate_sql).returns("update posts set id = 1").once
-      ActiveRecord::Base.connection.send(:exec_update, "update posts set id = 1")
-    ensure
-      ActiveRecord::Base.connection.unstub(:annotate_sql)
-    end
-
-    def test_query_commenting_on_postgres_delete
-      ActiveRecord::Base.connection.expects(:annotate_sql).returns("delete from posts where id = 1").once
-      ActiveRecord::Base.connection.send(:exec_delete, "delete from posts where id = 1")
-    ensure
-      ActiveRecord::Base.connection.unstub(:annotate_sql)
-    end
+  def test_query_commenting_on_postgres_delete
+    ActiveRecord::Base.connection.expects(:annotate_sql).returns("delete from posts where id = 1").once
+    ActiveRecord::Base.connection.send(:exec_delete, "delete from posts where id = 1")
+  ensure
+    ActiveRecord::Base.connection.unstub(:annotate_sql)
   end
 
   def test_configuring_application


### PR DESCRIPTION
we want to patch the pg gem directly to more easily support apps that do not use activerecord (i.e. sync).

since we are quite committed to postgres at travis, this seems like a reasonable choice.

this work is happening in collaboration with @clekstro.

refs travis-ci/travis-github-sync#76