### PR TITLE
Remove unsupported DB's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,8 @@
 language: ruby
 
 rvm:
-  - 2.4.2
+  - 2.5.0
 
 sudo: false
 
-script: bundle exec rake db:reset test:all
-
-env:
-  - "RAILS_VERSION=3.2.19"
-  - "RAILS_VERSION=4.0.8"
-  - "RAILS_VERSION=4.1.8"
-  - "RAILS_VERSION=4.2.0"
+script: bundle exec rake db:reset test:postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ rvm:
 
 sudo: false
 
+before_install:
+  - bash -c "yes | gem uninstall -i /home/travis/.rvm/gems/ruby-2.5.0@global rake"
+
 script: bundle exec rake db:reset test:postgresql

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,4 @@ gemspec
 
 version = ENV["RAILS_VERSION"] || "4.2.0"
 
-if "4.2.5" > version
-  gem 'mysql2', '~> 0.3.13'
-else
-  gem 'mysql2', '>= 0.3.13', '< 0.5'
-end
-
 gem "activerecord", "~> #{version}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 > Note: This is a fork of marginalia with the rails-specific stuff thrown out.
+> It targets Postgres and wraps the `pg` gem directly so as not to be coupled to
+> a specific ORM.
 
 # marginalia [![Build Status](https://travis-ci.org/travis-ci/marginalia.svg?branch=master)](https://travis-ci.org/travis-ci/marginalia)
 
@@ -19,11 +21,6 @@ to automate identification of controllers and actions that are hotspots for slow
 
 This gem was created at 37signals. You can read more about how we use it [on
 our blog](http://37signals.com/svn/posts/3130-tech-note-mysql-query-comments-in-rails).
-
-This has been tested and used in production with both the mysql and mysql2 gems,
-tested on Rails 2.3.5 through 4.1.x. It has also been tested for sqlite3 and postgres.
-
-Patches are welcome for other database adapters.
 
 ## Installation
 
@@ -51,9 +48,8 @@ Then in your code, register install the monkey patches:
 Start by bundling and creating the test database:
 
     bundle
-    rake db:mysql:create
     rake db:postgresql:create
 
-Then, running `rake` will run the tests on all the database adapters (`mysql`, `mysql2`, `postgresql` and `sqlite`):
+Then, running `rake` will run the tests on all the postgres adapter:
 
     rake

--- a/Rakefile
+++ b/Rakefile
@@ -5,12 +5,7 @@ task :default => ['test:all']
 
 namespace :test do
   desc "test all drivers"
-  task :all => [:mysql2, :postgresql, :sqlite]
-
-  desc "test mysql2 driver"
-  task :mysql2 do
-    sh "DRIVER=mysql2 ruby -Ilib -Itest test/*_test.rb"
-  end
+  task :all => [:postgresql, :sqlite]
 
   desc "test PostgreSQL driver"
   task :postgresql do
@@ -26,22 +21,7 @@ end
 namespace :db do
 
   desc "reset all databases"
-  task :reset => [:"mysql:reset", :"postgresql:reset"]
-
-  namespace :mysql do
-    desc "reset MySQL database"
-    task :reset => [:drop, :create]
-
-    desc "create MySQL database"
-    task :create do
-      sh 'mysql -u root -e "create database marginalia_test;"'
-    end
-
-    desc "drop MySQL database"
-    task :drop do
-      sh 'mysql -u root -e "drop database if exists marginalia_test;"'
-    end
-  end
+  task :reset => [:"postgresql:reset"]
 
   namespace :postgresql do
     desc "reset PostgreSQL database"

--- a/Rakefile
+++ b/Rakefile
@@ -1,25 +1,16 @@
 #!/usr/bin/env rake
 require "bundler/gem_tasks"
 
-task :default => ['test:all']
+task :default => ['test:postgresql']
 
 namespace :test do
-  desc "test all drivers"
-  task :all => [:postgresql, :sqlite]
-
   desc "test PostgreSQL driver"
   task :postgresql do
     sh "DRIVER=postgresql DB_USERNAME=postgres ruby -Ilib -Itest test/*_test.rb"
   end
-
-  desc "test sqlite3 driver"
-  task :sqlite do
-    sh "DRIVER=sqlite3 ruby -Ilib -Itest test/*_test.rb"
-  end
 end
 
 namespace :db do
-
   desc "reset all databases"
   task :reset => [:"postgresql:reset"]
 
@@ -37,5 +28,4 @@ namespace :db do
       sh 'psql -d postgres -U postgres -c "DROP DATABASE IF EXISTS marginalia_test"'
     end
   end
-
 end

--- a/lib/marginalia/active_record_instrumentation.rb
+++ b/lib/marginalia/active_record_instrumentation.rb
@@ -3,18 +3,6 @@ require 'active_record'
 module Marginalia
   module ActiveRecordInstrumentation
     def self.install
-      if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
-        ActiveRecord::ConnectionAdapters::Mysql2Adapter.module_eval do
-          include Marginalia::ActiveRecordInstrumentation
-        end
-      end
-
-      if defined? ActiveRecord::ConnectionAdapters::MysqlAdapter
-        ActiveRecord::ConnectionAdapters::MysqlAdapter.module_eval do
-          include Marginalia::ActiveRecordInstrumentation
-        end
-      end
-
       if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
         ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.module_eval do
           include Marginalia::ActiveRecordInstrumentation
@@ -39,16 +27,6 @@ module Marginalia
           alias_method :execute_and_clear_without_marginalia, :execute_and_clear
           alias_method :execute_and_clear, :execute_and_clear_with_marginalia
         else
-          is_mysql2 = defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter) &&
-            ActiveRecord::ConnectionAdapters::Mysql2Adapter == instrumented_class
-          # Dont instrument exec_query on mysql2 and AR 3.2+, as it calls execute internally
-          unless is_mysql2 && ActiveRecord::VERSION::STRING > "3.1"
-            if instrumented_class.method_defined?(:exec_query)
-              alias_method :exec_query_without_marginalia, :exec_query
-              alias_method :exec_query, :exec_query_with_marginalia
-            end
-          end
-
           is_postgres = defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) &&
             ActiveRecord::ConnectionAdapters::PostgreSQLAdapter == instrumented_class
           # Instrument exec_delete and exec_update on AR 3.2+, since they don't

--- a/lib/marginalia/active_record_instrumentation.rb
+++ b/lib/marginalia/active_record_instrumentation.rb
@@ -8,12 +8,6 @@ module Marginalia
           include Marginalia::ActiveRecordInstrumentation
         end
       end
-
-      if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
-        ActiveRecord::ConnectionAdapters::SQLite3Adapter.module_eval do
-          include Marginalia::ActiveRecordInstrumentation
-        end
-      end
     end
 
     def self.included(instrumented_class)

--- a/marginalia.gemspec
+++ b/marginalia.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "activerecord", ">= 2.3"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "mysql2"
   gem.add_development_dependency "pg"
   gem.add_development_dependency "sqlite3"
   gem.add_development_dependency "minitest"

--- a/marginalia.gemspec
+++ b/marginalia.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "activerecord", ">= 2.3"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "pg"
-  gem.add_development_dependency "sqlite3"
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "mocha"
 


### PR DESCRIPTION
We have no plans to support MySQL or SQLite, so removing the dependencies and code references so we can concentrate on Postgres going forward.