### PR TITLE
apply monkey-patch regardless of whether sequel or activerecord

### DIFF
--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -3,10 +3,7 @@ require 'marginalia/pg_instrumentation'
 
 module Marginalia
   def self.install
-    if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter ||
-          Sequel::Postgres::USES_PG
-      Marginalia::PgInstrumentation.install
-    end
+    Marginalia::PgInstrumentation.install
   end
 
   def self.set(key, value)


### PR DESCRIPTION
since we're now ORM agnostic, I think it makes sense to remove this check. it will also avoid issues with require ordering.